### PR TITLE
Adopt file URL scheme for dynamic imports in registry for Window

### DIFF
--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -13,7 +13,9 @@ import prompts from "prompts";
 import { handleError } from "@/src/utils/handle-error";
 import { registrySchema } from "@/src/utils/registry/schema";
 import { basename } from "path";
-
+import { pathToFileURL } from 'url';
+// Convert a file system path to a file URL
+const toFileUrl = (filePath) => pathToFileURL(filePath).href;
 const currentFileUrl = new URL(import.meta.url);
 const __dirname = path.dirname(currentFileUrl.pathname);
 
@@ -157,10 +159,10 @@ async function buildNextjs() {
   try {
   logger.info("Building registry for Next.js project...");
   const REGISTRY_PATH = path.join(process.cwd(), "public/registry");
-  const {registry: buildRegister} = await import(path.join(process.cwd(), "src/registry/registry.mjs"));
-  const {styles} = await import(path.join(process.cwd(), "src/registry/styles.mjs"));
-  const {colorMapping, colors} = await import(path.join(process.cwd(), "src/registry/colors.mjs"));;
-  const {themes} = await import(path.join(process.cwd(), "src/registry/themes.mjs"));
+  const {registry: buildRegister} = await import(toFileUrl(path.join(process.cwd(), "src/registry/registry.mjs")));
+  const {styles} = await import(toFileUrl(path.join(process.cwd(), "src/registry/styles.mjs")));
+  const {colorMapping, colors} = await import(toFileUrl(path.join(process.cwd(), "src/registry/colors.mjs")));;
+  const {themes} = await import(toFileUrl(path.join(process.cwd(), "src/registry/themes.mjs")));
 
   const result = registrySchema.safeParse(buildRegister);
   if (!result.success) {


### PR DESCRIPTION
This update introduces the use of file URLs instead of physical file paths when dynamically importing modules in our Next.js project's registry. The `toFileUrl` function, which utilizes the `pathToFileURL` function from the built-in URL API, has been added. This function converts a file system path to a file URL, providing the correct format for importing `registry.mjs`, `styles.mjs`, `colors.mjs`, and `themes.mjs`.

Switching to URLs from physical paths for imports prepares our code for better compatibility with potential future versions of ECMAScript Modules (ESM) that may strictly require URL-based addressing. Using file URLs is also advantageous due to their more consistent and standardized format across different operating systems.

This change should not affect the functionality of the application but forms part of our ongoing efforts to maintain code compliance with best practices and lookahead specifications.