### PR TITLE
feat: add claude-code provider — use Claude subscription, no API key …

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -83,7 +83,7 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
     cwd,
     overwrite = false,
     dryRun = false,
-    provider: providerName = "claude",
+    provider: providerName = "claude-code",
     model,
     apiKey,
     context7 = true,

--- a/src/agent/providers/claude-code.ts
+++ b/src/agent/providers/claude-code.ts
@@ -1,0 +1,212 @@
+import type {
+  AgentProvider,
+  GenerationMessage,
+  GenerationResult,
+  GeneratedFile,
+  ProviderOptions,
+} from "./types"
+import { execSync, type ExecSyncOptionsWithStringEncoding } from "child_process"
+
+// --- Claude Code provider: uses the `claude` CLI (works with your Claude subscription) ---
+
+export class ClaudeCodeProvider implements AgentProvider {
+  name = "claude-code"
+
+  constructor() {
+    // Verify claude CLI is available
+    try {
+      execSync("claude --version", { stdio: "pipe" })
+    } catch {
+      throw new Error(
+        "Claude Code CLI not found. Install it with: npm install -g @anthropic-ai/claude-code\n" +
+          "Then authenticate with: claude login\n" +
+          "This uses your Claude subscription — no API key needed."
+      )
+    }
+  }
+
+  async generate(
+    messages: GenerationMessage[],
+    options?: ProviderOptions
+  ): Promise<GenerationResult> {
+    // Build the prompt from messages
+    const systemMsg = messages.find((m) => m.role === "system")
+    const userMsgs = messages.filter((m) => m.role !== "system")
+
+    // Construct a single prompt that includes system context and conversation
+    const parts: string[] = []
+
+    if (systemMsg) {
+      parts.push(systemMsg.content)
+    }
+
+    // Add instruction to output structured JSON for file generation
+    parts.push(`
+CRITICAL OUTPUT FORMAT INSTRUCTION:
+You MUST respond with a valid JSON object and NOTHING else. No markdown fences, no explanation outside the JSON.
+The JSON must have this exact structure:
+{
+  "files": [
+    {
+      "path": "relative/path/to/file.ext",
+      "content": "full file content here",
+      "language": "typescript",
+      "description": "what this file does"
+    }
+  ],
+  "summary": "brief summary of what was generated",
+  "followUp": null
+}
+
+If you need to ask the user a clarifying question instead of generating files, respond with:
+{
+  "files": [],
+  "summary": "",
+  "followUp": "your question here"
+}
+
+Remember: Output ONLY the JSON object. No other text.`)
+
+    // Add conversation messages
+    for (const msg of userMsgs) {
+      if (msg.role === "user") {
+        parts.push(`\nUser request: ${msg.content}`)
+      } else if (msg.role === "assistant") {
+        parts.push(`\nPrevious assistant response: ${msg.content}`)
+      }
+    }
+
+    const fullPrompt = parts.join("\n\n")
+
+    // Use claude CLI in print mode (-p flag) with --output-format for structured output
+    const result = this.runClaude(fullPrompt, options)
+
+    return this.parseResponse(result)
+  }
+
+  private runClaude(prompt: string, options?: ProviderOptions): string {
+    // Build the command - use -p for print mode (non-interactive, single prompt)
+    // --output-format json gives us structured output
+    const args: string[] = ["-p", "--output-format", "json"]
+
+    // Add model if specified
+    if (options?.model) {
+      args.push("--model", options.model)
+    }
+
+    // Add max tokens if specified
+    if (options?.maxTokens) {
+      args.push("--max-turns", "1")
+    }
+
+    const cmd = `claude ${args.join(" ")}`
+
+    try {
+      const execOpts: ExecSyncOptionsWithStringEncoding = {
+        encoding: "utf-8",
+        maxBuffer: 50 * 1024 * 1024, // 50MB buffer for large outputs
+        timeout: 300000, // 5 min timeout
+        input: prompt,
+        stdio: ["pipe", "pipe", "pipe"],
+      }
+
+      const output = execSync(cmd, execOpts)
+      return output.toString().trim()
+    } catch (error: any) {
+      if (error.status === 127) {
+        throw new Error(
+          "Claude Code CLI not found. Install it with: npm install -g @anthropic-ai/claude-code"
+        )
+      }
+      // If the command ran but returned non-zero, stderr might have the error
+      if (error.stderr) {
+        const stderr = error.stderr.toString()
+        if (stderr.includes("not logged in") || stderr.includes("auth")) {
+          throw new Error(
+            "Claude Code not authenticated. Run: claude login"
+          )
+        }
+        throw new Error(`Claude Code error: ${stderr}`)
+      }
+      // If there's stdout even on error, try to use it
+      if (error.stdout) {
+        return error.stdout.toString().trim()
+      }
+      throw new Error(`Claude Code failed: ${error.message}`)
+    }
+  }
+
+  private parseResponse(raw: string): GenerationResult {
+    const files: GeneratedFile[] = []
+    let content = ""
+    let followUp: string | undefined
+
+    // The claude CLI with --output-format json returns a JSON object with a "result" field
+    try {
+      const outer = JSON.parse(raw)
+      // Claude CLI JSON output format: { result: "..." , ... }
+      const text = outer.result || outer.content || outer.text || raw
+
+      // Now try to parse the inner content as our structured format
+      return this.parseStructuredOutput(typeof text === "string" ? text : JSON.stringify(text))
+    } catch {
+      // Not valid JSON wrapper, try direct parse
+    }
+
+    // Try to parse as our structured JSON format directly
+    try {
+      return this.parseStructuredOutput(raw)
+    } catch {
+      // Not structured JSON
+    }
+
+    // Try to extract JSON from markdown code blocks
+    const jsonBlockMatch = raw.match(/```(?:json)?\s*\n([\s\S]*?)\n\s*```/)
+    if (jsonBlockMatch) {
+      try {
+        return this.parseStructuredOutput(jsonBlockMatch[1])
+      } catch {
+        // Not valid JSON in code block
+      }
+    }
+
+    // Fallback: try to extract any JSON object from the response
+    const jsonMatch = raw.match(/\{[\s\S]*"files"[\s\S]*\}/)
+    if (jsonMatch) {
+      try {
+        return this.parseStructuredOutput(jsonMatch[0])
+      } catch {
+        // Not valid JSON
+      }
+    }
+
+    // Last resort: return as plain text content
+    content = raw
+    return { content, files, followUp, tokensUsed: undefined }
+  }
+
+  private parseStructuredOutput(text: string): GenerationResult {
+    const data = JSON.parse(text)
+    const files: GeneratedFile[] = []
+
+    if (Array.isArray(data.files)) {
+      for (const f of data.files) {
+        if (f.path && f.content) {
+          files.push({
+            path: f.path,
+            content: f.content,
+            language: f.language,
+            description: f.description,
+          })
+        }
+      }
+    }
+
+    return {
+      content: data.summary || "",
+      files,
+      followUp: data.followUp || undefined,
+      tokensUsed: undefined, // Claude CLI doesn't expose token count
+    }
+  }
+}

--- a/src/agent/providers/index.ts
+++ b/src/agent/providers/index.ts
@@ -1,27 +1,31 @@
 import type { AgentProvider } from "./types"
 import { ClaudeProvider } from "./claude"
+import { ClaudeCodeProvider } from "./claude-code"
 
-export type ProviderName = "claude" | "openai" | "ollama" | "custom"
+export type ProviderName = "claude-code" | "claude" | "openai" | "ollama" | "custom"
 
 export function createProvider(
-  name: ProviderName = "claude",
+  name: ProviderName = "claude-code",
   apiKey?: string
 ): AgentProvider {
   switch (name) {
+    case "claude-code":
+      return new ClaudeCodeProvider()
     case "claude":
       return new ClaudeProvider(apiKey)
     case "openai":
       throw new Error(
-        "OpenAI provider coming soon. Set provider to 'claude' or contribute at github.com/anis-marrouchi/shadxn"
+        "OpenAI provider coming soon. Set provider to 'claude-code' or contribute at github.com/anis-marrouchi/shadxn"
       )
     case "ollama":
       throw new Error(
-        "Ollama provider coming soon. Set provider to 'claude' or contribute at github.com/anis-marrouchi/shadxn"
+        "Ollama provider coming soon. Set provider to 'claude-code' or contribute at github.com/anis-marrouchi/shadxn"
       )
     default:
-      throw new Error(`Unknown provider: ${name}. Supported: claude`)
+      throw new Error(`Unknown provider: ${name}. Supported: claude-code, claude`)
   }
 }
 
 export { ClaudeProvider } from "./claude"
+export { ClaudeCodeProvider } from "./claude-code"
 export type { AgentProvider, GenerationMessage, GenerationResult, GeneratedFile, ProviderOptions } from "./types"

--- a/src/agent/providers/types.ts
+++ b/src/agent/providers/types.ts
@@ -43,7 +43,7 @@ export interface AgentProvider {
 // --- Agent configuration ---
 
 export const agentConfigSchema = z.object({
-  provider: z.enum(["claude", "openai", "ollama", "custom"]).default("claude"),
+  provider: z.enum(["claude-code", "claude", "openai", "ollama", "custom"]).default("claude-code"),
   model: z.string().optional(),
   apiKey: z.string().optional(),
   skills: z.array(z.string()).default([]),

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -166,8 +166,8 @@ export const create = new Command()
   )
   .option(
     "-p, --provider <provider>",
-    "AI provider",
-    "claude"
+    "AI provider (claude-code, claude)",
+    "claude-code"
   )
   .option("-m, --model <model>", "model to use")
   .option("--api-key <key>", "API key")

--- a/src/commands/evolve.ts
+++ b/src/commands/evolve.ts
@@ -39,8 +39,8 @@ export const evolve = new Command()
   )
   .option(
     "-p, --provider <provider>",
-    "AI provider",
-    "claude"
+    "AI provider (claude-code, claude)",
+    "claude-code"
   )
   .option("-m, --model <model>", "model to use")
   .option("--api-key <key>", "API key")

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -16,7 +16,7 @@ const generateOptionsSchema = z.object({
   output: z.string().optional(),
   overwrite: z.boolean().default(false),
   dryRun: z.boolean().default(false),
-  provider: z.enum(["claude", "openai", "ollama", "custom"]).default("claude"),
+  provider: z.enum(["claude-code", "claude", "openai", "ollama", "custom"]).default("claude-code"),
   model: z.string().optional(),
   apiKey: z.string().optional(),
   cwd: z.string(),
@@ -39,8 +39,8 @@ export const gen = new Command()
   .option("--dry-run", "preview without writing files", false)
   .option(
     "-p, --provider <provider>",
-    "AI provider (claude, openai, ollama)",
-    "claude"
+    "AI provider (claude-code, claude, openai, ollama)",
+    "claude-code"
   )
   .option("-m, --model <model>", "model to use")
   .option("--api-key <key>", "API key for the provider")

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -17,8 +17,8 @@ export const run = new Command()
   .option("--host <host>", "server host", "0.0.0.0")
   .option(
     "-p, --provider <provider>",
-    "AI provider",
-    "claude"
+    "AI provider (claude-code, claude)",
+    "claude-code"
   )
   .option("-m, --model <model>", "model to use")
   .option("--api-key <key>", "API key")

--- a/src/commands/skill.ts
+++ b/src/commands/skill.ts
@@ -114,8 +114,8 @@ skill
   .option("--tags <tags>", "comma-separated tags")
   .option(
     "-p, --provider <provider>",
-    "AI provider for generation",
-    "claude"
+    "AI provider for generation (claude-code, claude)",
+    "claude-code"
   )
   .option("-m, --model <model>", "model to use")
   .option("--api-key <key>", "API key")

--- a/src/runtime/enhance.ts
+++ b/src/runtime/enhance.ts
@@ -30,7 +30,7 @@ const DEFAULT_CONFIG: EnhanceConfig = {
   enabled: true,
   autoSkills: true,
   minFrequency: 3,
-  provider: "claude",
+  provider: "claude-code",
 }
 
 export class EnhanceEngine {

--- a/src/runtime/heal.ts
+++ b/src/runtime/heal.ts
@@ -33,7 +33,7 @@ export interface HealResult {
 const DEFAULT_HEAL_CONFIG: HealConfig = {
   enabled: true,
   maxAttempts: 3,
-  provider: "claude",
+  provider: "claude-code",
 }
 
 export class HealEngine {

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -31,7 +31,7 @@ export interface RuntimeConfig {
 const DEFAULT_CONFIG: RuntimeConfig = {
   port: 3170,
   host: "0.0.0.0",
-  provider: "claude",
+  provider: "claude-code",
   cwd: process.cwd(),
   memory: { enabled: true },
   heal: { enabled: true },


### PR DESCRIPTION
…needed

Adds a new `claude-code` provider that shells out to the `claude` CLI in print mode (-p). This lets users run shadxn with their existing Claude subscription instead of needing a separate API key.

- claude-code is now the default provider across all commands
- Falls back to structured JSON output parsing with multiple extraction strategies
- Existing `claude` provider (direct API) still available via --provider claude
- Updated: generate, evolve, create, skill, run, serve commands + runtime defaults

https://claude.ai/code/session_012SfxPqzMUKYFT9gswYH942